### PR TITLE
Add CSV exports of Timeless Jewel Notables to the Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .vs
-**/Build/*
+**/Build
 **/output-data/*
+!**/output-data/readme.md
 **/source-data/*
+!**/source-data/readme.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vs
+**/Build/*
+**/output-data/*
+**/source-data/*

--- a/Datafile Generator/DatafileGenerator/DatafileGenerator.csproj
+++ b/Datafile Generator/DatafileGenerator/DatafileGenerator.csproj
@@ -11,23 +11,9 @@
 		<PackageReference Include="Spectre.Console" Version="0.55.2" />
 	</ItemGroup>
 	<ItemGroup>
-	  <Compile Update="Source\Data\Models\AlternatePassiveAddition.cs">
-	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-	  </Compile>
-	  <Compile Update="Source\Data\Models\AlternatePassiveSkill.cs">
-	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-	  </Compile>
-	  <Compile Update="Source\Data\Models\AlternateTreeVersion.cs">
-	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-	  </Compile>
-	  <Compile Update="Source\Data\Models\PassiveSkill.cs">
-	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-	  </Compile>
-	  <Compile Update="Source\Data\Models\TreeDataFile.cs">
-	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-	  </Compile>
-	</ItemGroup>
-	<ItemGroup>
+	  <None Update="output-data\README.md">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </None>
 	  <None Update="source-data\alternatepassiveadditions.json">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </None>
@@ -35,6 +21,9 @@
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </None>
 	  <None Update="source-data\data.json">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </None>
+	  <None Update="source-data\README.md">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </None>
 	</ItemGroup>

--- a/Datafile Generator/DatafileGenerator/DatafileGenerator.csproj
+++ b/Datafile Generator/DatafileGenerator/DatafileGenerator.csproj
@@ -6,7 +6,37 @@
 		<Configurations>Debug;Release;aaaaaaaaa</Configurations>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Spectre.Console" Version="0.44.0" />
+		<PackageReference Include="ServiceStack" Version="10.0.6" />
+		<PackageReference Include="ServiceStack.Text" Version="10.0.6" />
+		<PackageReference Include="Spectre.Console" Version="0.55.2" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Compile Update="Source\Data\Models\AlternatePassiveAddition.cs">
+	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+	  </Compile>
+	  <Compile Update="Source\Data\Models\AlternatePassiveSkill.cs">
+	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+	  </Compile>
+	  <Compile Update="Source\Data\Models\AlternateTreeVersion.cs">
+	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+	  </Compile>
+	  <Compile Update="Source\Data\Models\PassiveSkill.cs">
+	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+	  </Compile>
+	  <Compile Update="Source\Data\Models\TreeDataFile.cs">
+	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+	  </Compile>
+	</ItemGroup>
+	<ItemGroup>
+	  <None Update="source-data\alternatepassiveadditions.json">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </None>
+	  <None Update="source-data\alternatepassiveskills.json">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </None>
+	  <None Update="source-data\data.json">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </None>
 	</ItemGroup>
 	<Target Name="CopyContentFilesToOutputDirectory" AfterTargets="Build;CopyAllFilesToSingleFolderForPackage">
 		<ItemGroup>

--- a/Datafile Generator/DatafileGenerator/Directory.Build.props
+++ b/Datafile Generator/DatafileGenerator/Directory.Build.props
@@ -5,5 +5,6 @@
 		<BaseOutputPath>Build\Output</BaseOutputPath>
 		<IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)</IntermediateOutputPath>
 		<OutputPath>$(BaseOutputPath)\$(Configuration)</OutputPath>
+		<DebugType>portable</DebugType>
 	</PropertyGroup>
 </Project>

--- a/Datafile Generator/DatafileGenerator/Directory.Build.props
+++ b/Datafile Generator/DatafileGenerator/Directory.Build.props
@@ -5,6 +5,5 @@
 		<BaseOutputPath>Build\Output</BaseOutputPath>
 		<IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)</IntermediateOutputPath>
 		<OutputPath>$(BaseOutputPath)\$(Configuration)</OutputPath>
-		<DebugType>portable</DebugType>
 	</PropertyGroup>
 </Project>

--- a/Datafile Generator/DatafileGenerator/Source/AffectedNotablesCalculator.cs
+++ b/Datafile Generator/DatafileGenerator/Source/AffectedNotablesCalculator.cs
@@ -1,0 +1,201 @@
+using DatafileGenerator.Data;
+using DatafileGenerator.Data.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DatafileGenerator;
+
+// Example usage:
+// var calculator = new AffectedNotablesCalculator();
+// var mapping = calculator.GetNotableToSocketMapping();
+// // Returns: { "Flaying": 36931, "Backstabbing": 36932, ... }
+// Console.WriteLine($"Flaying is affected by socket: {mapping["Flaying"]}");
+
+public class Point
+{
+    public double X { get; set; }
+    public double Y { get; set; }
+
+    public Point(double x, double y)
+    {
+        X = x;
+        Y = y;
+    }
+}
+
+public class SkillNode
+{
+    public string NodeId { get; set; }
+    public int? Skill { get; set; }
+    public string Name { get; set; }
+    public bool IsNotable { get; set; }
+    public bool IsJewelSocket { get; set; }
+    public int? Group { get; set; }
+    public int? Orbit { get; set; }
+    public int? OrbitIndex { get; set; }
+}
+
+public class SkillTreeData
+{
+    public Dictionary<int, SkillGroup> Groups { get; set; }
+    public Dictionary<string, SkillNode> Nodes { get; set; }
+    public SkillTreeConstants Constants { get; set; }
+    public double MinX { get; set; }
+    public double MinY { get; set; }
+}
+
+public class AffectedNotablesCalculator
+{
+    private const int BaseJewelRadius = 1800;
+    private static readonly int[] Orbit16Angles = { 0, 30, 45, 60, 90, 120, 135, 150, 180, 210, 225, 240, 270, 300, 315, 330 };
+    private static readonly int[] Orbit40Angles = {
+        0, 10, 20, 30, 40, 45, 50, 60, 70, 80, 90, 100, 110, 120, 130, 135, 140, 150, 160, 170, 180, 190, 200, 210, 220, 225,
+        230, 240, 250, 260, 270, 280, 290, 300, 310, 315, 320, 330, 340, 350
+    };
+
+    private readonly SkillTreeData _skillTree;
+
+    public AffectedNotablesCalculator()
+    {
+        _skillTree = new SkillTreeData
+        {
+            Groups = DataManager.FullTreeData.Groups,
+            Nodes = DataManager.FullTreeData.PassiveSkills.ToDictionary(
+                kvp => kvp.Key,
+                kvp => new SkillNode
+                {
+                    NodeId = kvp.Key,
+                    Skill = (int?)kvp.Value.GraphIdentifier,
+                    Name = kvp.Value.Name,
+                    IsNotable = kvp.Value.IsNotable,
+                    IsJewelSocket = kvp.Value.IsJewelSocket,
+                    Group = kvp.Value.Group,
+                    Orbit = (int?)kvp.Value.Orbit,
+                    OrbitIndex = kvp.Value.OrbitIndex
+                }),
+            Constants = DataManager.FullTreeData.Constants,
+            MinX = DataManager.FullTreeData.MinX,
+            MinY = DataManager.FullTreeData.MinY
+        };
+    }
+
+    /// <summary>
+    /// Gets a mapping of Notable skill names to the Jewel Socket ID that affects them.
+    /// Returns Dictionary&lt;string, int&gt; where key is notable name, value is socket skill ID.
+    /// </summary>
+    public Dictionary<string, int> GetNotableToSocketMapping()
+    {
+        var mapping = new Dictionary<string, int>();
+
+        // Get all jewel sockets
+        var jewelSockets = _skillTree.Nodes.Values.Where(n => n.IsJewelSocket).ToList();
+
+        // For each notable, find the closest jewel socket within radius
+        foreach (var notable in _skillTree.Nodes.Values.Where(n => n.IsNotable))
+        {
+            var notablePos = CalculateNodePos(notable);
+            SkillNode closestSocket = null;
+            double closestDistance = double.MaxValue;
+
+            foreach (var socket in jewelSockets)
+            {
+                var socketPos = CalculateNodePos(socket);
+                var distance = Distance(notablePos, socketPos);
+
+                if (distance < BaseJewelRadius && distance < closestDistance)
+                {
+                    closestDistance = distance;
+                    closestSocket = socket;
+                }
+            }
+
+            if (closestSocket != null && closestSocket.Skill.HasValue)
+            {
+                mapping[notable.Name] = closestSocket.Skill.Value;
+            }
+        }
+
+        return mapping;
+    }
+
+    /// <summary>
+    /// Calculates the position of a node on the skill tree.
+    /// </summary>
+    private Point CalculateNodePos(SkillNode node)
+    {
+        if (!node.Group.HasValue || !node.Orbit.HasValue || !node.OrbitIndex.HasValue)
+            return new Point(0, 0);
+
+        var targetGroup = _skillTree.Groups[node.Group.Value];
+        var targetAngle = OrbitAngleAt(node.Orbit.Value, node.OrbitIndex.Value);
+
+        var targetGroupPos = ToCanvasCoords(targetGroup.X, targetGroup.Y);
+        var targetNodePos = ToCanvasCoords(
+            targetGroup.X,
+            targetGroup.Y - _skillTree.Constants.OrbitRadii[node.Orbit.Value]
+        );
+
+        return RotateAroundPoint(targetGroupPos, targetNodePos, targetAngle);
+    }
+
+    /// <summary>
+    /// Converts tree coordinates to canvas coordinates.
+    /// </summary>
+    private Point ToCanvasCoords(double x, double y)
+    {
+        // With offsetX=0, offsetY=0, scaling=1
+        return new Point(
+            Math.Abs(_skillTree.MinX) + x,
+            Math.Abs(_skillTree.MinY) + y
+        );
+    }
+
+    /// <summary>
+    /// Rotates a point around a center point by the given angle (in degrees).
+    /// </summary>
+    private Point RotateAroundPoint(Point center, Point target, double angle)
+    {
+        var radians = (Math.PI / 180) * angle;
+        var cos = Math.Cos(radians);
+        var sin = Math.Sin(radians);
+
+        var nx = cos * (target.X - center.X) + sin * (target.Y - center.Y) + center.X;
+        var ny = cos * (target.Y - center.Y) - sin * (target.X - center.X) + center.Y;
+
+        return new Point(nx, ny);
+    }
+
+    /// <summary>
+    /// Gets the rotation angle for a node at the given orbit and index position.
+    /// </summary>
+    private double OrbitAngleAt(int orbit, int index)
+    {
+        int nodesInOrbit = orbit < _skillTree.Constants.SkillsPerOrbit.Length ? _skillTree.Constants.SkillsPerOrbit[orbit] : 16;
+
+        if (nodesInOrbit == 16)
+        {
+            int clampedIndex = Math.Clamp(index, 1, 16);
+            return Orbit16Angles[16 - clampedIndex];
+        }
+        else if (nodesInOrbit == 40)
+        {
+            int clampedIndex = Math.Clamp(index, 1, 40);
+            return Orbit40Angles[40 - clampedIndex];
+        }
+        else
+        {
+            return 360 - (360.0 / nodesInOrbit) * index;
+        }
+    }
+
+    /// <summary>
+    /// Calculates the Euclidean distance between two points.
+    /// </summary>
+    private double Distance(Point p1, Point p2)
+    {
+        var dx = p1.X - p2.X;
+        var dy = p1.Y - p2.Y;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+}

--- a/Datafile Generator/DatafileGenerator/Source/AffectedNotablesCalculator.cs
+++ b/Datafile Generator/DatafileGenerator/Source/AffectedNotablesCalculator.cs
@@ -88,8 +88,8 @@ public class AffectedNotablesCalculator
     {
         var mapping = new Dictionary<string, int>();
 
-        // Get all jewel sockets
-        var jewelSockets = _skillTree.Nodes.Values.Where(n => n.IsJewelSocket).ToList();
+        // Get all Basic and Large (aka cluster) jewel sockets
+        var jewelSockets = _skillTree.Nodes.Values.Where(n => n.IsJewelSocket && (n.Name == "Basic Jewel Socket" || n.Name == "Large Jewel Socket")).ToList();
 
         // For each notable, find the closest jewel socket within radius
         foreach (var notable in _skillTree.Nodes.Values.Where(n => n.IsNotable))

--- a/Datafile Generator/DatafileGenerator/Source/Data/DataManager.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/DataManager.cs
@@ -18,12 +18,15 @@ public static class DataManager
 
     public static IReadOnlyCollection<PassiveSkill> PassiveSkills { get; private set; }
 
+    public static TreeDataFile FullTreeData { get; private set; }
+
     public static bool Initialize()
     {
         AlternatePassiveAdditions = LoadFromFile<AlternatePassiveAddition>(GeneratorSettings.AlternatePassiveAdditionsFilePath);
         AlternatePassiveSkills = LoadFromFile<AlternatePassiveSkill>(GeneratorSettings.AlternatePassiveSkillsFilePath);
         AlternateTreeVersions = GetAlternateTrees();
-        var treeData = LoadSingleFromFile<TreeDataFile>(GeneratorSettings.PassiveSkillsFilePath).PassiveSkills;
+        FullTreeData = LoadSingleFromFile<TreeDataFile>(GeneratorSettings.PassiveSkillsFilePath);
+        var treeData = FullTreeData.PassiveSkills;
         treeData.Remove("root");
         PassiveSkills = treeData.Values.ToList();
 

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/AlternatePassiveAddition.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/AlternatePassiveAddition.cs
@@ -12,7 +12,7 @@ public class AlternatePassiveAddition
     [JsonPropertyName("AlternateTreeVersionsKey")]
     public uint AlternateTreeVersionIndex { get; init; }
 
-    [JsonPropertyName("Name")]
+    [JsonPropertyName("Id")]
     public string Name { get; init; }
 
     [JsonPropertyName("StatsKeys")]

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/AlternatePassiveAddition.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/AlternatePassiveAddition.cs
@@ -12,6 +12,9 @@ public class AlternatePassiveAddition
     [JsonPropertyName("AlternateTreeVersionsKey")]
     public uint AlternateTreeVersionIndex { get; init; }
 
+    [JsonPropertyName("Name")]
+    public string Name { get; init; }
+
     [JsonPropertyName("StatsKeys")]
     public IReadOnlyCollection<uint> StatIndices { get; init; }
 

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/AlternatePassiveSkill.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/AlternatePassiveSkill.cs
@@ -11,6 +11,9 @@ public class AlternatePassiveSkill
     [JsonPropertyName("AlternateTreeVersionsKey")]
     public uint AlternateTreeVersionIndex { get; init; }
 
+    [JsonPropertyName("Name")]
+    public string Name { get; init; }
+
     [JsonPropertyName("StatsKeys")]
     public IReadOnlyCollection<uint> StatIndices { get; init; }
 

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/CsvExportRow.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/CsvExportRow.cs
@@ -1,19 +1,28 @@
 ﻿using DatafileGenerator.Data.Models;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace DatafileGenerator.Source.Data.Models
 {
     public class CsvExportRow
     {
         public int JewelSeed { get; set; }
-        public int JewelType { get; set; }
-        public string JewelName { get; set; }
         public int JewelSocketId { get; set; }
 
-        public string NotableName { get; set; }
-        public string NotableReplacementName { get; set; }
-        public uint NotableReplacementIndex { get; set; }
+        [IgnoreDataMember]
+        public int JewelType { get; set; }
+        [IgnoreDataMember]
+        public string JewelName { get; set; }
 
+        [IgnoreDataMember]
+        public uint NotableId { get; set; }
+        [IgnoreDataMember]
+        public string NotableName { get; set; }
+
+        [IgnoreDataMember]
+        public uint NotableReplacementIndex { get; set; }
+        public string NotableReplacementName { get; set; }
+        
         public CsvExportRow(
             int jewelSeed,
             string jewelName,
@@ -30,6 +39,7 @@ namespace DatafileGenerator.Source.Data.Models
             JewelSocketId = notableJewelSocketMappings.ContainsKey(notable.Name) ? notableJewelSocketMappings[notable.Name] : 0;
 
             NotableName = notable.Name;
+            NotableId = notable.GraphIdentifier;
             NotableReplacementName = notableJewelReplacementName;
             NotableReplacementIndex = notableIndex;
         }

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/CsvExportRow.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/CsvExportRow.cs
@@ -20,17 +20,17 @@ namespace DatafileGenerator.Source.Data.Models
             int jewelType,
             PassiveSkill notable,
             uint notableIndex,
-            AlternatePassiveSkill notableJewelReplacement,
-            Dictionary<string, int> notableJewelSocketmappings
+            string notableJewelReplacementName,
+            Dictionary<string, int> notableJewelSocketMappings
         )
         {
             JewelSeed = jewelSeed;
             JewelType = jewelType;
             JewelName = jewelName;
-            JewelSocketId = notableJewelSocketmappings.ContainsKey(notable.Name) ? notableJewelSocketmappings[notable.Name] : 0;
+            JewelSocketId = notableJewelSocketMappings.ContainsKey(notable.Name) ? notableJewelSocketMappings[notable.Name] : 0;
 
             NotableName = notable.Name;
-            NotableReplacementName = notableJewelReplacement.Name;
+            NotableReplacementName = notableJewelReplacementName;
             NotableReplacementIndex = notableIndex;
         }
     }

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/CsvExportRow.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/CsvExportRow.cs
@@ -16,7 +16,6 @@ namespace DatafileGenerator.Source.Data.Models
 
         [IgnoreDataMember]
         public uint NotableId { get; set; }
-        [IgnoreDataMember]
         public string NotableName { get; set; }
 
         [IgnoreDataMember]

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/CsvExportRow.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/CsvExportRow.cs
@@ -1,4 +1,5 @@
 ﻿using DatafileGenerator.Data.Models;
+using System.Collections.Generic;
 
 namespace DatafileGenerator.Source.Data.Models
 {
@@ -7,31 +8,30 @@ namespace DatafileGenerator.Source.Data.Models
         public int JewelSeed { get; set; }
         public int JewelType { get; set; }
         public string JewelName { get; set; }
+        public int JewelSocketId { get; set; }
 
         public string NotableName { get; set; }
-
         public string NotableReplacementName { get; set; }
+        public uint NotableReplacementIndex { get; set; }
 
-        public uint? Orbit { get; set; }
-
-        public uint NotableIndex { get; set; }
-
-        public byte PassiveSkillIndex { get; set; }
-
-        public CsvExportRow(int jewelSeed, string jewelName, int jewelType, PassiveSkill notable, uint notableIndex, AlternatePassiveSkill notableJewelReplacement)
+        public CsvExportRow(
+            int jewelSeed,
+            string jewelName,
+            int jewelType,
+            PassiveSkill notable,
+            uint notableIndex,
+            AlternatePassiveSkill notableJewelReplacement,
+            Dictionary<string, int> notableJewelSocketmappings
+        )
         {
             JewelSeed = jewelSeed;
-            JewelName = jewelName;
             JewelType = jewelType;
-            AddNotableMapping(notable, notableIndex, notableJewelReplacement);
-        }
+            JewelName = jewelName;
+            JewelSocketId = notableJewelSocketmappings.ContainsKey(notable.Name) ? notableJewelSocketmappings[notable.Name] : 0;
 
-        public void AddNotableMapping(PassiveSkill notable, uint notableIndex, AlternatePassiveSkill notableJewelReplacement)
-        {
             NotableName = notable.Name;
             NotableReplacementName = notableJewelReplacement.Name;
-            Orbit = notable.Orbit;
-            NotableIndex = notableIndex;
+            NotableReplacementIndex = notableIndex;
         }
     }
 }

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/CsvExportRow.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/CsvExportRow.cs
@@ -1,0 +1,37 @@
+﻿using DatafileGenerator.Data.Models;
+
+namespace DatafileGenerator.Source.Data.Models
+{
+    public class CsvExportRow
+    {
+        public int JewelSeed { get; set; }
+        public int JewelType { get; set; }
+        public string JewelName { get; set; }
+
+        public string NotableName { get; set; }
+
+        public string NotableReplacementName { get; set; }
+
+        public uint? Orbit { get; set; }
+
+        public uint NotableIndex { get; set; }
+
+        public byte PassiveSkillIndex { get; set; }
+
+        public CsvExportRow(int jewelSeed, string jewelName, int jewelType, PassiveSkill notable, uint notableIndex, AlternatePassiveSkill notableJewelReplacement)
+        {
+            JewelSeed = jewelSeed;
+            JewelName = jewelName;
+            JewelType = jewelType;
+            AddNotableMapping(notable, notableIndex, notableJewelReplacement);
+        }
+
+        public void AddNotableMapping(PassiveSkill notable, uint notableIndex, AlternatePassiveSkill notableJewelReplacement)
+        {
+            NotableName = notable.Name;
+            NotableReplacementName = notableJewelReplacement.Name;
+            Orbit = notable.Orbit;
+            NotableIndex = notableIndex;
+        }
+    }
+}

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/PassiveSkill.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/PassiveSkill.cs
@@ -40,6 +40,12 @@ public class PassiveSkill : IComparable<PassiveSkill>
 
     [JsonPropertyName("orbit")]
     public uint? Orbit { get; init; }
+
+    [JsonPropertyName("group")]
+    public int? Group { get; init; }
+
+    [JsonPropertyName("orbitIndex")]
+    public int? OrbitIndex { get; init; }
     public bool IsCluster => Orbit == null;
     public bool IsAttribute => 
         StatStrings != null && StatStrings.Count == 1 &&

--- a/Datafile Generator/DatafileGenerator/Source/Data/Models/TreeDataFile.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Data/Models/TreeDataFile.cs
@@ -3,9 +3,45 @@ using System.Text.Json.Serialization;
 
 namespace DatafileGenerator.Data.Models
 {
+    public class SkillGroup
+    {
+        [JsonPropertyName("x")]
+        public double X { get; set; }
+
+        [JsonPropertyName("y")]
+        public double Y { get; set; }
+
+        [JsonPropertyName("orbits")]
+        public int[] Orbits { get; set; }
+
+        [JsonPropertyName("nodes")]
+        public string[] Nodes { get; set; }
+    }
+
+    public class SkillTreeConstants
+    {
+        [JsonPropertyName("skillsPerOrbit")]
+        public int[] SkillsPerOrbit { get; set; }
+
+        [JsonPropertyName("orbitRadii")]
+        public int[] OrbitRadii { get; set; }
+    }
+
     public class TreeDataFile
     {
+        [JsonPropertyName("groups")]
+        public Dictionary<int, SkillGroup> Groups { get; set; }
+
         [JsonPropertyName("nodes")]
         public Dictionary<string, PassiveSkill> PassiveSkills { get; set; }
+
+        [JsonPropertyName("constants")]
+        public SkillTreeConstants Constants { get; set; }
+
+        [JsonPropertyName("min_x")]
+        public double MinX { get; set; }
+
+        [JsonPropertyName("min_y")]
+        public double MinY { get; set; }
     }
 }

--- a/Datafile Generator/DatafileGenerator/Source/GeneratorSettings.cs
+++ b/Datafile Generator/DatafileGenerator/Source/GeneratorSettings.cs
@@ -5,7 +5,7 @@ namespace DatafileGenerator;
 public static class GeneratorSettings
 {
     public static readonly string ApplicationName = "DatafileGenerator";
-    public static readonly Version ApplicationVersion = new Version(1, 2);
+    public static readonly Version ApplicationVersion = new Version(1, 3);
 
     public static string AlternatePassiveAdditionsFilePath;
     public static string AlternatePassiveSkillsFilePath;

--- a/Datafile Generator/DatafileGenerator/Source/Program.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Program.cs
@@ -1,15 +1,18 @@
-﻿using System;
+﻿using DatafileGenerator.Data;
+using DatafileGenerator.Data.Models;
+using DatafileGenerator.Game;
+using DatafileGenerator.Source.Data.Models;
+using ServiceStack.Text;
+using Spectre.Console;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Spectre.Console;
-using DatafileGenerator.Data;
-using DatafileGenerator.Data.Models;
-using DatafileGenerator.Game;
-using System.IO.Compression;
 
 namespace DatafileGenerator;
 
@@ -19,7 +22,6 @@ public static class Program
     private const int MightOfTheVaal = 76;
     private const int LegacyOfTheVaal = 77;
     private const int MaxBytesInFile = 5242880; //5MB
-    private static int NumAdditions;
     private const string LuaMappingFileName = "NodeIndexMapping.lua";
     private const string CsvFileName = "node_indices.csv";
 
@@ -28,17 +30,32 @@ public static class Program
         Console.Title = $"{GeneratorSettings.ApplicationName} (v{GeneratorSettings.ApplicationVersion})";
         //prompt
         AnsiConsole.MarkupLine("Spinning up!");
-        PromptUserForFile("Path to [yellow]alternate passive ADDITIONS[/] file:", out GeneratorSettings.AlternatePassiveAdditionsFilePath);
-        PromptUserForFile("Path to [yellow]alternate passive SKILLS[/] file:", out GeneratorSettings.AlternatePassiveSkillsFilePath);
-        PromptUserForFile("Path to [yellow]skill tree[/] file:", out GeneratorSettings.PassiveSkillsFilePath);
-        PromptUserForFile("Path to [yellow]output[/] directory:", out string outputDir, true);
-        PromptUserForChoice("Output type:", new List<string>() { "compressed", "uncompressed", "both" }, out int compression);
-        compression += 1; //hacky but it turns it into a bitmask by doing this
+
+        GeneratorSettings.AlternatePassiveAdditionsFilePath = Path.GetFullPath(@"source-data\alternatepassiveadditions.json");
+        if(!File.Exists(GeneratorSettings.AlternatePassiveAdditionsFilePath)){
+            PromptUserForFile("Path to [yellow]alternate passive ADDITIONS[/] file:", out GeneratorSettings.AlternatePassiveAdditionsFilePath);
+        }
+        GeneratorSettings.AlternatePassiveSkillsFilePath = Path.GetFullPath(@"source-data\alternatepassiveskills.json");
+        if(!File.Exists(GeneratorSettings.AlternatePassiveAdditionsFilePath)){
+            PromptUserForFile("Path to [yellow]alternate passive SKILLS[/] file:", out GeneratorSettings.AlternatePassiveSkillsFilePath);
+        }
+        GeneratorSettings.PassiveSkillsFilePath = Path.GetFullPath(@"source-data\data.json");
+        if(!File.Exists(GeneratorSettings.AlternatePassiveAdditionsFilePath)){
+            PromptUserForFile("Path to [yellow]skill tree[/] file:", out GeneratorSettings.PassiveSkillsFilePath);
+        }
+        var outputDir = Path.GetFullPath(@"output-data");
+        if(!File.Exists(GeneratorSettings.AlternatePassiveAdditionsFilePath)){
+            PromptUserForFile("Path to [yellow]output[/] directory:", out outputDir, true);
+        }
+        
+        var exportOptions = new List<string>() { "compressed", "uncompressed", "csv", "both" };
+        PromptUserForChoice("Output type:", exportOptions, out int compressionChoice);
+        var compression = exportOptions.ElementAt(compressionChoice);
+
         AnsiConsole.MarkupLine("[green]Loading[/]...");
 
         if (!DataManager.Initialize())
             ExitWithError("Failed to initialize the [yellow]data manager[/].");
-        NumAdditions = DataManager.AlternatePassiveAdditions.Count;
         if (!Directory.Exists(outputDir))
             Directory.CreateDirectory(outputDir);
 
@@ -63,14 +80,19 @@ public static class Program
         sb.Clear();
         //begin iterating over the 5 jewel types
         //reverse order since glorious vanity sucks
+        string outputPath = null;
         for (int i = 6; i > 0; i--)
         {
             var sw = Stopwatch.StartNew();
             GetJewelTypeInfo(i, out _, out _, out _, out string outputFile);
             byte[] dataBuffer;
+            List<CsvExportRow> csvExport;
             //glorious vanity logic
             if (i == 1)
             {
+                // TODO - Remove this temporary skip logic for glorious vanity
+                continue;
+
                 //calculate
                 GenerateGloriousVanity(notablesThenSmalls, out var luaSizes, out dataBuffer);
                 //create the lua mapping file
@@ -90,23 +112,21 @@ public static class Program
             //non-glorious vanity logic
             else
             {
-                GenerateRegular(justNotables, i, out dataBuffer);
+                GenerateRegular(justNotables, i, out dataBuffer, out csvExport);
             }
             //output uncompressed
-            if ((compression & 2) == 2)
+            if (compression == "uncompressed" || compression == "both")
             {
-                string outputPath = Path.Combine(outputDir, outputFile);
+                outputPath = Path.Combine(outputDir, outputFile);
                 if (File.Exists(outputPath))
                 {
                     File.Delete(outputPath);
                 }
-                using (Stream file = File.OpenWrite(outputPath))
-                {
-                    file.Write(dataBuffer, 0, dataBuffer.Length);
-                }
+                using Stream file = File.OpenWrite(outputPath);
+                file.Write(dataBuffer, 0, dataBuffer.Length);
             }
             //output compressed
-            if ((compression & 1) == 1)
+            if (compression == "compressed" || compression == "both")
             {
                 byte[] compressedData = Compress(dataBuffer);
                 //need to split into multiple files because PoB is dumb
@@ -117,7 +137,7 @@ public static class Program
                     while (split.Any())
                     {
                         //write the data
-                        string outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, $"zip.part{splitIndex}"));
+                        outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, $"zip.part{splitIndex}"));
                         if (File.Exists(outputPath))
                         {
                             File.Delete(outputPath);
@@ -132,20 +152,33 @@ public static class Program
                 //file is small enough as is, just write the file
                 else
                 {
-                    string outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, "zip"));
+                    outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, "zip"));
                     if (File.Exists(outputPath))
                     {
                         File.Delete(outputPath);
                     }
-                    using (Stream file = File.OpenWrite(outputPath))
-                    {
-                        file.Write(compressedData, 0, compressedData.Length);
-                    }
+                    using Stream file = File.OpenWrite(outputPath);
+                    file.Write(compressedData, 0, compressedData.Length);
                 }
+            }
+            if (compression == "csv")
+            {
+                AnsiConsole.MarkupLine("Exporting CSVs");
+                outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, "csv"));
+                if (File.Exists(outputPath))
+                {
+                    File.Delete(outputPath);
+                }
+
+                File.WriteAllText(outputPath, CsvSerializer.SerializeToCsv(csvExport));
             }
             //log completion
             sw.Stop();
             Console.WriteLine($"{outputFile} took {sw.Elapsed.TotalSeconds} seconds");
+            if (outputPath != null)
+            {
+                Console.WriteLine($"File available at: {outputPath}");
+            }
         }
         AnsiConsole.MarkupLine("[green]Done[/]!");
     }
@@ -235,20 +268,36 @@ public static class Program
         data = outputData.ToArray();
     }
 
-    private static void GenerateRegular(List<PassiveSkill> nodes, int jewelType, out byte[] data)
+    private static void GenerateRegular(List<PassiveSkill> nodes, int jewelType, out byte[] data, out List<CsvExportRow> csvData)
     {
-        GetJewelTypeInfo(jewelType, out int jewelMin, out int jewelMax, out int jewelIncrement, out _);
+        GetJewelTypeInfo(jewelType, out int jewelMin, out int jewelMax, out int jewelIncrement, out string jewelName);
         int maxSeed = (jewelMax - jewelMin) / jewelIncrement + 1;
         byte[] dataInternal = new byte[maxSeed * nodes.Count];
+
         //re-index our additions and replacements to consider only this jewel type
         uint numAdditions = (uint)DataManager.AlternatePassiveAdditions.Count;
-        var jewelEffectOptions = DataManager.AlternatePassiveAdditions.Where(x => x.AlternateTreeVersionIndex == jewelType).Select(x => x.Index)
-            .Concat(DataManager.AlternatePassiveSkills.Where(x => x.AlternateTreeVersionIndex == jewelType).Select(x => x.Index + numAdditions))
-            .Select((x, i) => new { rid = x, index = (byte)i }).ToDictionary(x => x.rid, x => x.index);
+
+        var jewelEffectOptions =
+            DataManager.AlternatePassiveAdditions
+                .Where(x => x.AlternateTreeVersionIndex == jewelType)
+                .Select(x => x.Index)
+                .Concat(
+                    DataManager.AlternatePassiveSkills
+                        .Where(x => x.AlternateTreeVersionIndex == jewelType)
+                        .Select(x => x.Index + numAdditions)
+                )
+                .Select((x, i) => new { rid = x, index = (byte)i })
+                .ToDictionary(x => x.rid, x => x.index);
+
+        var notableJewelReplacements = DataManager.AlternatePassiveSkills
+                .Where(x => x.AlternateTreeVersionIndex == jewelType)
+                .ToDictionary(x => x.Index, x => x);
+
         if (jewelEffectOptions.Count > 256)
         {
             throw new Exception("Cannot safely construct file: possible indices greater than byte size");
         }
+        var export = new ConcurrentBag<CsvExportRow>();
         //for non glorious vanity, we only care about notables
         Parallel.For(0, nodes.Count, notableIndex =>
         {
@@ -270,7 +319,9 @@ public static class Program
                 byte passiveSkillIndex = 0;
                 if (flag)
                 {
-                    passiveSkillIndex = jewelEffectOptions[alternateTreeManager.ReplacePassiveSkill().AlternatePassiveSkill.Index + numAdditions];
+                    var notableIndex = alternateTreeManager.ReplacePassiveSkill().AlternatePassiveSkill.Index;
+                    passiveSkillIndex = jewelEffectOptions[notableIndex + numAdditions];
+                    export.Add(new CsvExportRow(jewel_seed, jewelName, jewel_type, notable, notableIndex, notableJewelReplacements[notableIndex]));
                 }
                 else
                 {
@@ -280,6 +331,7 @@ public static class Program
             });
         });
         data = dataInternal;
+        csvData = export.ToList();
     }
 
     private static void GetJewelTypeInfo(int jewelType, out int jewelMin, out int jewelMax, out int jewelIncrement, out string jewelName)
@@ -346,7 +398,7 @@ public static class Program
     private static TimelessJewel GetTimelessJewel(uint seed, uint jewelType)
     {
         AlternateTreeVersion alternateTreeVersion = DataManager.AlternateTreeVersions
-            .First(q => (q.Index == jewelType));
+            .First(q => q.Index == jewelType);
         return new TimelessJewel(alternateTreeVersion, seed);
     }
 
@@ -378,7 +430,7 @@ public static class Program
     private static void PromptUserForFile(string query, out string response, bool isDir = false)
     {
         TextPrompt<string> fileTextPrompt = new TextPrompt<string>(query)
-            .Validate((string input) =>
+            .Validate(input =>
             {
                 if (!isDir && !File.Exists(input))
                 {

--- a/Datafile Generator/DatafileGenerator/Source/Program.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Program.cs
@@ -185,7 +185,14 @@ public static class Program
                     File.Delete(outputPath);
                 }
 
-                File.WriteAllText(outputPath, CsvSerializer.SerializeToCsv(csvExport));
+                File.WriteAllText(
+                    outputPath, 
+                    CsvSerializer.SerializeToCsv(
+                        csvExport
+                            .OrderBy(s => s.JewelSeed)
+                            .ThenBy(s => s.JewelSocketId)
+                    )
+                );
             }
             //log completion
             sw.Stop();

--- a/Datafile Generator/DatafileGenerator/Source/Program.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Program.cs
@@ -2,6 +2,7 @@
 using DatafileGenerator.Data.Models;
 using DatafileGenerator.Game;
 using DatafileGenerator.Source.Data.Models;
+using ServiceStack;
 using ServiceStack.Text;
 using Spectre.Console;
 using System;
@@ -29,7 +30,7 @@ public static class Program
     {
         Console.Title = $"{GeneratorSettings.ApplicationName} (v{GeneratorSettings.ApplicationVersion})";
         //prompt
-        AnsiConsole.MarkupLine("Spinning up!");
+        AnsiConsole.MarkupLine("[green]Spinning up[/]!");
 
         // Load input files
         GeneratorSettings.AlternatePassiveAdditionsFilePath = Path.GetFullPath(@"source-data\alternatepassiveadditions.json");
@@ -50,7 +51,7 @@ public static class Program
         }
         
         var exportOptions = new List<string>() { "compressed", "uncompressed", "csv", "both" };
-        PromptUserForChoice("Output type:", exportOptions, out int compressionChoice);
+        PromptUserForChoice("Select output type:", exportOptions, out int compressionChoice);
         var compression = exportOptions.ElementAt(compressionChoice);
 
         AnsiConsole.MarkupLine("[green]Loading[/]...");
@@ -60,13 +61,13 @@ public static class Program
         if (!Directory.Exists(outputDir))
             Directory.CreateDirectory(outputDir);
 
-        Dictionary<string, int> notableJewelSocketmappings = null;
+        Dictionary<string, int> notableJewelSocketMappings = null;
         if (compression == "csv")
         {
-            AnsiConsole.MarkupLine("[green]Calculating Notable Mappings[/]...");
+            AnsiConsole.MarkupLine("[green]Calculating Notable skills affected by jewel radii[/]...");
             var calculator = new AffectedNotablesCalculator();
-            notableJewelSocketmappings = calculator.GetNotableToSocketMapping();
-            AnsiConsole.MarkupLine($"{notableJewelSocketmappings.Count} Notable Mappings Loaded");
+            notableJewelSocketMappings = calculator.GetNotableToSocketMapping();
+            AnsiConsole.MarkupLine($"{notableJewelSocketMappings.Count} Affected Notable skills found");
         }
 
         var justNotables = GetModifiableNodes(true);
@@ -100,7 +101,7 @@ public static class Program
             //glorious vanity logic
             if (i == 1)
             {
-                AnsiConsole.MarkupLine("[green]Calculating Glorious Vanity Seeds[/]...");
+                AnsiConsole.MarkupLine("[green]Calculating Glorious Vanity seeds[/]...");
                 // TODO - Remove this temporary skip logic for glorious vanity
                 continue;
 
@@ -123,12 +124,12 @@ public static class Program
             //non-glorious vanity logic
             else
             {
-                GenerateRegular(justNotables, i, notableJewelSocketmappings, out dataBuffer, out csvExport);
+                GenerateRegular(justNotables, i, notableJewelSocketMappings, out dataBuffer, out csvExport);
             }
             //output uncompressed
             if (compression == "uncompressed" || compression == "both")
             {
-                AnsiConsole.MarkupLine("[green]Generating Uncompressed Output File[/]...");
+                AnsiConsole.MarkupLine("[green]Generating uncompressed output file[/]...");
                 outputPath = Path.Combine(outputDir, outputFile);
                 if (File.Exists(outputPath))
                 {
@@ -140,7 +141,7 @@ public static class Program
             //output compressed
             if (compression == "compressed" || compression == "both")
             {
-                AnsiConsole.MarkupLine("[green]Generating Compressed Output File[/]...");
+                AnsiConsole.MarkupLine("[green]Generating compressed output file[/]...");
                 byte[] compressedData = Compress(dataBuffer);
                 //need to split into multiple files because PoB is dumb
                 if (compressedData.Length > MaxBytesInFile)
@@ -176,7 +177,7 @@ public static class Program
             }
             if (compression == "csv")
             {
-                AnsiConsole.MarkupLine("[green]Generating CSV File[/]...");
+                AnsiConsole.MarkupLine("[green]Generating CSV file[/]...");
                 outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, "csv"));
                 if (File.Exists(outputPath))
                 {
@@ -281,11 +282,11 @@ public static class Program
         data = outputData.ToArray();
     }
 
-    private static void GenerateRegular(List<PassiveSkill> nodes, int jewelType, Dictionary<string, int> notableJewelSocketmappings, out byte[] data, out List<CsvExportRow> csvData)
+    private static void GenerateRegular(List<PassiveSkill> nodes, int jewelType, Dictionary<string, int> notableJewelSocketMappings, out byte[] data, out List<CsvExportRow> csvData)
     {
         GetJewelTypeInfo(jewelType, out int jewelMin, out int jewelMax, out int jewelIncrement, out string jewelName);
 
-        AnsiConsole.MarkupLine($"[green]Calculating {jewelName} Seeds[/]...");
+        AnsiConsole.MarkupLine($"[green]Calculating {jewelName} seeds[/]...");
 
         int maxSeed = (jewelMax - jewelMin) / jewelIncrement + 1;
         byte[] dataInternal = new byte[maxSeed * nodes.Count];
@@ -305,9 +306,21 @@ public static class Program
                 .Select((x, i) => new { rid = x, index = (byte)i })
                 .ToDictionary(x => x.rid, x => x.index);
 
-        var notableJewelReplacements = DataManager.AlternatePassiveSkills
+        var timelessJewelsWithAdditions = new string[] { "LethalPride", "BrutalRestraint" };
+        Dictionary<uint, string> notableJewelReplacementNames;
+
+        if (timelessJewelsWithAdditions.Contains(jewelName))
+        {
+            notableJewelReplacementNames = DataManager.AlternatePassiveAdditions
                 .Where(x => x.AlternateTreeVersionIndex == jewelType)
-                .ToDictionary(x => x.Index, x => x);
+                .ToDictionary(x => x.Index, x => x.Name);
+        }
+        else
+        {
+            notableJewelReplacementNames = DataManager.AlternatePassiveSkills
+                .Where(x => x.AlternateTreeVersionIndex == jewelType)
+                .ToDictionary(x => x.Index, x => x.Name);
+        }
 
         if (jewelEffectOptions.Count > 256)
         {
@@ -333,29 +346,38 @@ public static class Program
                 var alternateTreeManager = new AlternateTreeManager(notable, timelessJewelFromInput);
                 bool flag = alternateTreeManager.IsPassiveSkillReplaced();
                 byte passiveSkillIndex = 0;
+                uint notableIndex = 0;
+                AlternatePassiveSkill notableJewelReplacement = null;
+                string notableReplacementName = string.Empty;
                 if (flag)
                 {
-                    var notableIndex = alternateTreeManager.ReplacePassiveSkill().AlternatePassiveSkill.Index;
+                    notableIndex = alternateTreeManager.ReplacePassiveSkill().AlternatePassiveSkill.Index;
+                    notableReplacementName = notableJewelReplacementNames[notableIndex];
                     passiveSkillIndex = jewelEffectOptions[notableIndex + numAdditions];
-                    var exportRow = new CsvExportRow(
-                        jewel_seed,
-                        jewelName,
-                        jewel_type,
-                        notable,
-                        notableIndex,
-                        notableJewelReplacements[notableIndex],
-                        notableJewelSocketmappings
-                    );
-                    // A JewelSocketId of 0 indicates that the notable does not appear in the radius of a jewel socket
-                    if (exportRow.JewelSocketId > 0)
-                    {
-                        export.Add(exportRow);
-                    }
                 }
                 else
                 {
-                    passiveSkillIndex = jewelEffectOptions[alternateTreeManager.AugmentPassiveSkill().First().AlternatePassiveAddition.Index];
+                    var augment = alternateTreeManager.AugmentPassiveSkill().FirstOrDefault();
+                    notableIndex = augment?.AlternatePassiveAddition.Index ?? 0;
+                    notableReplacementName = notableJewelReplacementNames[notableIndex];
+                    passiveSkillIndex = jewelEffectOptions[notableIndex];
                 }
+
+                var exportRow = new CsvExportRow(
+                    jewel_seed,
+                    jewelName,
+                    jewel_type,
+                    notable,
+                    notableIndex,
+                    notableReplacementName,
+                    notableJewelSocketMappings
+                );
+                // A JewelSocketId of 0 indicates that the notable does not appear in the radius of a jewel socket
+                if (exportRow.JewelSocketId > 0)
+                {
+                    export.Add(exportRow);
+                }
+
                 dataInternal[notableIndex * maxSeed + jewel_index] = passiveSkillIndex;
             });
         });

--- a/Datafile Generator/DatafileGenerator/Source/Program.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Program.cs
@@ -143,7 +143,7 @@ public static class Program
                 }
                 using (Stream file = File.OpenWrite(outputPath))
                 {
-                file.Write(dataBuffer, 0, dataBuffer.Length);
+                    file.Write(dataBuffer, 0, dataBuffer.Length);
                 }
             }
             //output compressed
@@ -181,7 +181,7 @@ public static class Program
                     }
                     using (Stream file = File.OpenWrite(outputPath))
                     {
-                    file.Write(compressedData, 0, compressedData.Length);
+                        file.Write(compressedData, 0, compressedData.Length);
                     }
                 }
             }
@@ -368,20 +368,19 @@ public static class Program
                 var alternateTreeManager = new AlternateTreeManager(notable, timelessJewelFromInput);
                 bool flag = alternateTreeManager.IsPassiveSkillReplaced();
                 byte passiveSkillIndex = 0;
-                uint notableIndex = 0;
-                AlternatePassiveSkill notableJewelReplacement = null;
+                uint notableAlternatePassiveIndex = 0;
                 string notableReplacementName = string.Empty;
                 if (flag)
                 {
-                    notableIndex = alternateTreeManager.ReplacePassiveSkill().AlternatePassiveSkill.Index;
-                    notableReplacementName = notableJewelReplacementNames[notableIndex];
-                    passiveSkillIndex = jewelEffectOptions[notableIndex + numAdditions];
+                    notableAlternatePassiveIndex = alternateTreeManager.ReplacePassiveSkill().AlternatePassiveSkill.Index;
+                    notableReplacementName = notableJewelReplacementNames[notableAlternatePassiveIndex];
+                    passiveSkillIndex = jewelEffectOptions[notableAlternatePassiveIndex + numAdditions];
                 }
                 else
                 {
-                    notableIndex = alternateTreeManager.AugmentPassiveSkill().FirstOrDefault()?.AlternatePassiveAddition.Index ?? 0;
-                    notableReplacementName = notableJewelReplacementNames[notableIndex];
-                    passiveSkillIndex = jewelEffectOptions[notableIndex];
+                    notableAlternatePassiveIndex = alternateTreeManager.AugmentPassiveSkill().FirstOrDefault()?.AlternatePassiveAddition.Index ?? 0;
+                    notableReplacementName = notableJewelReplacementNames[notableAlternatePassiveIndex];
+                    passiveSkillIndex = jewelEffectOptions[notableAlternatePassiveIndex];
                 }
 
                 if(isCsvExport){
@@ -390,7 +389,7 @@ public static class Program
                         jewelName,
                         jewel_type,
                         notable,
-                        notableIndex,
+                        notableAlternatePassiveIndex,
                         notableReplacementName,
                         notableJewelSocketMappings
                     );
@@ -460,13 +459,15 @@ public static class Program
 
     private static byte[] Compress(byte[] data)
     {
-        var internalMemoryStream = new MemoryStream();
-        //deflate it to the smallest size. we have time.
-        using (var deflateStream = new ZLibStream(internalMemoryStream, CompressionLevel.SmallestSize))
+        using (var internalMemoryStream = new MemoryStream())
         {
-            deflateStream.Write(data, 0, data.Length);
-        }
-        return internalMemoryStream.ToArray();
+            //deflate it to the smallest size. we have time.
+            using (var deflateStream = new ZLibStream(internalMemoryStream, CompressionLevel.SmallestSize))
+            {
+                deflateStream.Write(data, 0, data.Length);
+            }
+            return internalMemoryStream.ToArray();
+        }        
     }
 
     private static TimelessJewel GetTimelessJewel(uint seed, uint jewelType)

--- a/Datafile Generator/DatafileGenerator/Source/Program.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Program.cs
@@ -31,6 +31,7 @@ public static class Program
         //prompt
         AnsiConsole.MarkupLine("Spinning up!");
 
+        // Load input files
         GeneratorSettings.AlternatePassiveAdditionsFilePath = Path.GetFullPath(@"source-data\alternatepassiveadditions.json");
         if(!File.Exists(GeneratorSettings.AlternatePassiveAdditionsFilePath)){
             PromptUserForFile("Path to [yellow]alternate passive ADDITIONS[/] file:", out GeneratorSettings.AlternatePassiveAdditionsFilePath);
@@ -58,6 +59,15 @@ public static class Program
             ExitWithError("Failed to initialize the [yellow]data manager[/].");
         if (!Directory.Exists(outputDir))
             Directory.CreateDirectory(outputDir);
+
+        Dictionary<string, int> notableJewelSocketmappings = null;
+        if (compression == "csv")
+        {
+            AnsiConsole.MarkupLine("[green]Calculating Notable Mappings[/]...");
+            var calculator = new AffectedNotablesCalculator();
+            notableJewelSocketmappings = calculator.GetNotableToSocketMapping();
+            AnsiConsole.MarkupLine($"{notableJewelSocketmappings.Count} Notable Mappings Loaded");
+        }
 
         var justNotables = GetModifiableNodes(true);
         var justSmallNodes = GetModifiableNodes(false);
@@ -90,6 +100,7 @@ public static class Program
             //glorious vanity logic
             if (i == 1)
             {
+                AnsiConsole.MarkupLine("[green]Calculating Glorious Vanity Seeds[/]...");
                 // TODO - Remove this temporary skip logic for glorious vanity
                 continue;
 
@@ -112,11 +123,12 @@ public static class Program
             //non-glorious vanity logic
             else
             {
-                GenerateRegular(justNotables, i, out dataBuffer, out csvExport);
+                GenerateRegular(justNotables, i, notableJewelSocketmappings, out dataBuffer, out csvExport);
             }
             //output uncompressed
             if (compression == "uncompressed" || compression == "both")
             {
+                AnsiConsole.MarkupLine("[green]Generating Uncompressed Output File[/]...");
                 outputPath = Path.Combine(outputDir, outputFile);
                 if (File.Exists(outputPath))
                 {
@@ -128,6 +140,7 @@ public static class Program
             //output compressed
             if (compression == "compressed" || compression == "both")
             {
+                AnsiConsole.MarkupLine("[green]Generating Compressed Output File[/]...");
                 byte[] compressedData = Compress(dataBuffer);
                 //need to split into multiple files because PoB is dumb
                 if (compressedData.Length > MaxBytesInFile)
@@ -163,7 +176,7 @@ public static class Program
             }
             if (compression == "csv")
             {
-                AnsiConsole.MarkupLine("Exporting CSVs");
+                AnsiConsole.MarkupLine("[green]Generating CSV File[/]...");
                 outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, "csv"));
                 if (File.Exists(outputPath))
                 {
@@ -174,13 +187,13 @@ public static class Program
             }
             //log completion
             sw.Stop();
-            Console.WriteLine($"{outputFile} took {sw.Elapsed.TotalSeconds} seconds");
+            AnsiConsole.MarkupLine($"{outputFile} took {string.Format("{0:0.##}", sw.Elapsed.TotalSeconds)} seconds");
             if (outputPath != null)
             {
-                Console.WriteLine($"File available at: {outputPath}");
+                AnsiConsole.MarkupLine($"[blue]File available at:[/] {outputPath}");
             }
         }
-        AnsiConsole.MarkupLine("[green]Done[/]!");
+        AnsiConsole.MarkupLine("[blue]Done[/]!");
     }
 
     private static List<PassiveSkill> GetModifiableNodes(bool notables)
@@ -268,9 +281,12 @@ public static class Program
         data = outputData.ToArray();
     }
 
-    private static void GenerateRegular(List<PassiveSkill> nodes, int jewelType, out byte[] data, out List<CsvExportRow> csvData)
+    private static void GenerateRegular(List<PassiveSkill> nodes, int jewelType, Dictionary<string, int> notableJewelSocketmappings, out byte[] data, out List<CsvExportRow> csvData)
     {
         GetJewelTypeInfo(jewelType, out int jewelMin, out int jewelMax, out int jewelIncrement, out string jewelName);
+
+        AnsiConsole.MarkupLine($"[green]Calculating {jewelName} Seeds[/]...");
+
         int maxSeed = (jewelMax - jewelMin) / jewelIncrement + 1;
         byte[] dataInternal = new byte[maxSeed * nodes.Count];
 
@@ -321,7 +337,20 @@ public static class Program
                 {
                     var notableIndex = alternateTreeManager.ReplacePassiveSkill().AlternatePassiveSkill.Index;
                     passiveSkillIndex = jewelEffectOptions[notableIndex + numAdditions];
-                    export.Add(new CsvExportRow(jewel_seed, jewelName, jewel_type, notable, notableIndex, notableJewelReplacements[notableIndex]));
+                    var exportRow = new CsvExportRow(
+                        jewel_seed,
+                        jewelName,
+                        jewel_type,
+                        notable,
+                        notableIndex,
+                        notableJewelReplacements[notableIndex],
+                        notableJewelSocketmappings
+                    );
+                    // A JewelSocketId of 0 indicates that the notable does not appear in the radius of a jewel socket
+                    if (exportRow.JewelSocketId > 0)
+                    {
+                        export.Add(exportRow);
+                    }
                 }
                 else
                 {

--- a/Datafile Generator/DatafileGenerator/Source/Program.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Program.cs
@@ -22,6 +22,7 @@ public static class Program
 
     private const int MightOfTheVaal = 76;
     private const int LegacyOfTheVaal = 77;
+
     private const int MaxBytesInFile = 5242880; //5MB
     private const string LuaMappingFileName = "NodeIndexMapping.lua";
     private const string CsvFileName = "node_indices.csv";
@@ -50,9 +51,10 @@ public static class Program
             PromptUserForFile("Path to [yellow]output[/] directory:", out outputDir, true);
         }
         
-        var exportOptions = new List<string>() { "compressed", "uncompressed", "csv", "both" };
+        var exportOptions = new List<string>() { "compressed", "uncompressed", "both", "csv" };
         PromptUserForChoice("Select output type:", exportOptions, out int compressionChoice);
         var compression = exportOptions.ElementAt(compressionChoice);
+        var isCsvExport = compression == "csv";
 
         AnsiConsole.MarkupLine("[green]Loading[/]...");
 
@@ -62,7 +64,7 @@ public static class Program
             Directory.CreateDirectory(outputDir);
 
         Dictionary<string, int> notableJewelSocketMappings = null;
-        if (compression == "csv")
+        if (isCsvExport)
         {
             AnsiConsole.MarkupLine("[green]Calculating Notable skills affected by jewel radii[/]...");
             var calculator = new AffectedNotablesCalculator();
@@ -92,21 +94,20 @@ public static class Program
         //begin iterating over the 5 jewel types
         //reverse order since glorious vanity sucks
         string outputPath = null;
+        List<CsvExportRow> csvExport;
         for (int i = 6; i > 0; i--)
         {
             var sw = Stopwatch.StartNew();
             GetJewelTypeInfo(i, out _, out _, out _, out string outputFile);
             byte[] dataBuffer;
-            List<CsvExportRow> csvExport;
+            csvExport = null;
             //glorious vanity logic
             if (i == 1)
             {
                 AnsiConsole.MarkupLine("[green]Calculating Glorious Vanity seeds[/]...");
-                // TODO - Remove this temporary skip logic for glorious vanity
-                continue;
 
                 //calculate
-                GenerateGloriousVanity(notablesThenSmalls, out var luaSizes, out dataBuffer);
+                GenerateGloriousVanity(notablesThenSmalls, isCsvExport, notableJewelSocketMappings, out var luaSizes, out dataBuffer, out csvExport);
                 //create the lua mapping file
                 sb.Clear();
                 sb.AppendLine("nodeIDList = { }");
@@ -175,7 +176,7 @@ public static class Program
                     file.Write(compressedData, 0, compressedData.Length);
                 }
             }
-            if (compression == "csv")
+            if (isCsvExport)
             {
                 AnsiConsole.MarkupLine("[green]Generating CSV file[/]...");
                 outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, "csv"));
@@ -202,9 +203,9 @@ public static class Program
         return DataManager.PassiveSkills.Where(x => x.IsModifiable && (!notables ^ x.IsNotable)).ToList();
     }
 
-    private static void GenerateGloriousVanity(List<PassiveSkill> nodes, out int[] luaDefinitions, out byte[] data)
+    private static void GenerateGloriousVanity(List<PassiveSkill> nodes, bool isCsvExport, Dictionary<string, int> notableJewelSocketMappings, out int[] luaDefinitions, out byte[] data, out List<CsvExportRow> csvData)
     {
-        GetJewelTypeInfo(1, out int jewelMin, out int jewelMax, out int jewelIncrement, out _);
+        GetJewelTypeInfo(1, out int jewelMin, out int jewelMax, out int jewelIncrement, out string jewelName);
         int maxSeed = (jewelMax - jewelMin) / jewelIncrement + 1;
         //the datafile header. cant use out params in anonymous methods
         byte[] header = new byte[maxSeed * nodes.Count];
@@ -220,10 +221,16 @@ public static class Program
         {
             throw new Exception("Cannot safely construct file: possible indices greater than byte size");
         }
-        //nested parallell tasks, in case your cpu wasnt on fire yet
+        var export = new ConcurrentBag<CsvExportRow>();
+        //nested parallel tasks, in case your cpu wasn't on fire yet
         Parallel.For(0, nodes.Count, nodeIndex =>
         {
             var node = nodes[nodeIndex];
+            if (isCsvExport && !node.IsNotable)
+            {
+                return;
+            }
+            
             Parallel.For(jewelMin / jewelIncrement, jewelMax / jewelIncrement + 1, i =>
             {
                 //which jewel seed is this
@@ -261,16 +268,32 @@ public static class Program
                         rolls.Add((byte)skillInfo.StatRolls[(uint)k]);
                     }
                 }
+
                 //save the data
                 var dataEntry = new List<byte>(indices);
                 dataEntry.AddRange(rolls);
                 header[nodeIndex * maxSeed + jewelIndex] = (byte)dataEntry.Count;
                 data2d[nodeIndex * maxSeed + jewelIndex] = dataEntry.ToArray();
+
+                var exportRow = new CsvExportRow(
+                    jewelSeed,
+                    jewelName,
+                    jewelType,
+                    node,
+                    (uint)nodeIndex,
+                    skillInfo.AlternatePassiveSkill.Name,
+                    notableJewelSocketMappings
+                );
+                // A JewelSocketId of 0 indicates that the notable does not appear in the radius of a jewel socket
+                if (exportRow.JewelSocketId > 0)
+                {
+                    export.Add(exportRow);
+                }
             });
         });
         //write the data
         var outputData = new List<byte>(header);
-        foreach (var entry in data2d)
+        foreach (var entry in data2d.Where(d => d is not null))
         {
             outputData.AddRange(entry);
         }
@@ -280,6 +303,7 @@ public static class Program
             luaDefinitions[i] = header.Skip(i * maxSeed).Take(maxSeed).Sum(x => x);
         }
         data = outputData.ToArray();
+        csvData = export.ToList();
     }
 
     private static void GenerateRegular(List<PassiveSkill> nodes, int jewelType, Dictionary<string, int> notableJewelSocketMappings, out byte[] data, out List<CsvExportRow> csvData)

--- a/Datafile Generator/DatafileGenerator/Source/Program.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Program.cs
@@ -24,6 +24,7 @@ public static class Program
     private const int LegacyOfTheVaal = 77;
 
     private const int MaxBytesInFile = 5242880; //5MB
+    private static int NumAdditions;
     private const string LuaMappingFileName = "NodeIndexMapping.lua";
     private const string CsvFileName = "node_indices.csv";
 
@@ -39,22 +40,28 @@ public static class Program
             PromptUserForFile("Path to [yellow]alternate passive ADDITIONS[/] file:", out GeneratorSettings.AlternatePassiveAdditionsFilePath);
         }
         GeneratorSettings.AlternatePassiveSkillsFilePath = Path.GetFullPath(@"source-data\alternatepassiveskills.json");
-        if(!File.Exists(GeneratorSettings.AlternatePassiveAdditionsFilePath)){
+        if(!File.Exists(GeneratorSettings.AlternatePassiveSkillsFilePath)){
             PromptUserForFile("Path to [yellow]alternate passive SKILLS[/] file:", out GeneratorSettings.AlternatePassiveSkillsFilePath);
         }
         GeneratorSettings.PassiveSkillsFilePath = Path.GetFullPath(@"source-data\data.json");
-        if(!File.Exists(GeneratorSettings.AlternatePassiveAdditionsFilePath)){
+        if(!File.Exists(GeneratorSettings.PassiveSkillsFilePath)){
             PromptUserForFile("Path to [yellow]skill tree[/] file:", out GeneratorSettings.PassiveSkillsFilePath);
         }
         var outputDir = Path.GetFullPath(@"output-data");
-        if(!File.Exists(GeneratorSettings.AlternatePassiveAdditionsFilePath)){
+        if(!Directory.Exists(outputDir)){
             PromptUserForFile("Path to [yellow]output[/] directory:", out outputDir, true);
         }
         
-        var exportOptions = new List<string>() { "compressed", "uncompressed", "both", "csv" };
+        const string OutputCompressedFiles = "compressed";
+        const string OutputUncompressedFiles = "uncompressed";
+        const string OutputBothFileFormats = "both";
+        const string OutputCsvFiles = "csv";
+        const string OutputCsvFilesCompressed = "csv (compressed)";
+        var exportOptions = new List<string>() { OutputCompressedFiles, OutputUncompressedFiles, OutputBothFileFormats, OutputCsvFiles, OutputCsvFilesCompressed };
         PromptUserForChoice("Select output type:", exportOptions, out int compressionChoice);
         var compression = exportOptions.ElementAt(compressionChoice);
-        var isCsvExport = compression == "csv";
+        var isCsvExport = compression == OutputCsvFiles || compression == OutputCsvFilesCompressed;
+        var compressCSVOutput = compression == OutputCsvFilesCompressed;
 
         AnsiConsole.MarkupLine("[green]Loading[/]...");
 
@@ -100,7 +107,7 @@ public static class Program
             var sw = Stopwatch.StartNew();
             GetJewelTypeInfo(i, out _, out _, out _, out string outputFile);
             byte[] dataBuffer;
-            csvExport = null;
+
             //glorious vanity logic
             if (i == 1)
             {
@@ -125,10 +132,10 @@ public static class Program
             //non-glorious vanity logic
             else
             {
-                GenerateRegular(justNotables, i, notableJewelSocketMappings, out dataBuffer, out csvExport);
+                GenerateRegular(justNotables, isCsvExport, i, notableJewelSocketMappings, out dataBuffer, out csvExport);
             }
-            //output uncompressed
-            if (compression == "uncompressed" || compression == "both")
+
+            if (compression == OutputUncompressedFiles || compression == OutputBothFileFormats)
             {
                 AnsiConsole.MarkupLine("[green]Generating uncompressed output file[/]...");
                 outputPath = Path.Combine(outputDir, outputFile);
@@ -136,11 +143,13 @@ public static class Program
                 {
                     File.Delete(outputPath);
                 }
-                using Stream file = File.OpenWrite(outputPath);
+                using (Stream file = File.OpenWrite(outputPath))
+                {
                 file.Write(dataBuffer, 0, dataBuffer.Length);
+                }
             }
-            //output compressed
-            if (compression == "compressed" || compression == "both")
+
+            if (compression == OutputCompressedFiles || compression == OutputBothFileFormats)
             {
                 AnsiConsole.MarkupLine("[green]Generating compressed output file[/]...");
                 byte[] compressedData = Compress(dataBuffer);
@@ -172,31 +181,18 @@ public static class Program
                     {
                         File.Delete(outputPath);
                     }
-                    using Stream file = File.OpenWrite(outputPath);
+                    using (Stream file = File.OpenWrite(outputPath))
+                    {
                     file.Write(compressedData, 0, compressedData.Length);
+                    }
                 }
             }
             if (isCsvExport)
             {
                 AnsiConsole.MarkupLine("[green]Generating GZipped CSV file[/]...");
-                outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, "csv.gz"));
-                if (File.Exists(outputPath))
-                {
-                    File.Delete(outputPath);
-                }
 
-                using (var fileStream = File.Create(outputPath))
-                using (var gzipStream = new GZipStream(fileStream, CompressionMode.Compress))
-                using (var writer = new StreamWriter(gzipStream))
-                {
-                    writer.Write(
-                        CsvSerializer.SerializeToCsv(
-                            csvExport
-                                .OrderBy(s => s.JewelSeed)
-                                .ThenBy(s => s.JewelSocketId)
-                        )
-                    );
-                }
+                outputPath = CreateCSVFile(csvExport, outputDir, outputFile, compressCSVOutput);
+                
             }
             //log completion
             sw.Stop();
@@ -239,6 +235,7 @@ public static class Program
             var node = nodes[nodeIndex];
             if (isCsvExport && !node.IsNotable)
             {
+                // The CSV export only includes notables, so skip small nodes to save time on the alternate tree calculations
                 return;
             }
             
@@ -286,19 +283,22 @@ public static class Program
                 header[nodeIndex * maxSeed + jewelIndex] = (byte)dataEntry.Count;
                 data2d[nodeIndex * maxSeed + jewelIndex] = dataEntry.ToArray();
 
-                var exportRow = new CsvExportRow(
-                    jewelSeed,
-                    jewelName,
-                    jewelType,
-                    node,
-                    (uint)nodeIndex,
-                    skillInfo.AlternatePassiveSkill.Name,
-                    notableJewelSocketMappings
-                );
-                // A JewelSocketId of 0 indicates that the notable does not appear in the radius of a jewel socket
-                if (exportRow.JewelSocketId > 0)
-                {
-                    export.Add(exportRow);
+                if(isCsvExport){
+                    var exportRow = new CsvExportRow(
+                        jewelSeed,
+                        jewelName,
+                        jewelType,
+                        node,
+                        (uint)nodeIndex,
+                        skillInfo.AlternatePassiveSkill.Name,
+                        notableJewelSocketMappings
+                    );
+                    // A JewelSocketId of 0 indicates that the notable does not appear
+                    // in the radius of a jewel socket...so don't export it to the CSV
+                    if (exportRow.JewelSocketId > 0)
+                    {
+                        export.Add(exportRow);
+                    }
                 }
             });
         });
@@ -317,7 +317,7 @@ public static class Program
         csvData = export.ToList();
     }
 
-    private static void GenerateRegular(List<PassiveSkill> nodes, int jewelType, Dictionary<string, int> notableJewelSocketMappings, out byte[] data, out List<CsvExportRow> csvData)
+    private static void GenerateRegular(List<PassiveSkill> nodes, bool isCsvExport, int jewelType, Dictionary<string, int> notableJewelSocketMappings, out byte[] data, out List<CsvExportRow> csvData)
     {
         GetJewelTypeInfo(jewelType, out int jewelMin, out int jewelMax, out int jewelIncrement, out string jewelName);
 
@@ -328,22 +328,12 @@ public static class Program
 
         //re-index our additions and replacements to consider only this jewel type
         uint numAdditions = (uint)DataManager.AlternatePassiveAdditions.Count;
+        var jewelEffectOptions = DataManager.AlternatePassiveAdditions.Where(x => x.AlternateTreeVersionIndex == jewelType).Select(x => x.Index)
+            .Concat(DataManager.AlternatePassiveSkills.Where(x => x.AlternateTreeVersionIndex == jewelType).Select(x => x.Index + numAdditions))
+            .Select((x, i) => new { rid = x, index = (byte)i }).ToDictionary(x => x.rid, x => x.index);
 
-        var jewelEffectOptions =
-            DataManager.AlternatePassiveAdditions
-                .Where(x => x.AlternateTreeVersionIndex == jewelType)
-                .Select(x => x.Index)
-                .Concat(
-                    DataManager.AlternatePassiveSkills
-                        .Where(x => x.AlternateTreeVersionIndex == jewelType)
-                        .Select(x => x.Index + numAdditions)
-                )
-                .Select((x, i) => new { rid = x, index = (byte)i })
-                .ToDictionary(x => x.rid, x => x.index);
-
-        var timelessJewelsWithAdditions = new string[] { "LethalPride", "BrutalRestraint" };
         Dictionary<uint, string> notableJewelReplacementNames;
-
+        var timelessJewelsWithAdditions = new string[] { "LethalPride", "BrutalRestraint" };
         if (timelessJewelsWithAdditions.Contains(jewelName))
         {
             notableJewelReplacementNames = DataManager.AlternatePassiveAdditions
@@ -355,12 +345,13 @@ public static class Program
             notableJewelReplacementNames = DataManager.AlternatePassiveSkills
                 .Where(x => x.AlternateTreeVersionIndex == jewelType)
                 .ToDictionary(x => x.Index, x => x.Name);
-        }
+        }        
 
         if (jewelEffectOptions.Count > 256)
         {
             throw new Exception("Cannot safely construct file: possible indices greater than byte size");
         }
+
         var export = new ConcurrentBag<CsvExportRow>();
         //for non glorious vanity, we only care about notables
         Parallel.For(0, nodes.Count, notableIndex =>
@@ -398,19 +389,21 @@ public static class Program
                     passiveSkillIndex = jewelEffectOptions[notableIndex];
                 }
 
-                var exportRow = new CsvExportRow(
-                    jewel_seed,
-                    jewelName,
-                    jewel_type,
-                    notable,
-                    notableIndex,
-                    notableReplacementName,
-                    notableJewelSocketMappings
-                );
-                // A JewelSocketId of 0 indicates that the notable does not appear in the radius of a jewel socket
-                if (exportRow.JewelSocketId > 0)
-                {
-                    export.Add(exportRow);
+                if(isCsvExport){
+                    var exportRow = new CsvExportRow(
+                        jewel_seed,
+                        jewelName,
+                        jewel_type,
+                        notable,
+                        notableIndex,
+                        notableReplacementName,
+                        notableJewelSocketMappings
+                    );
+                    // A JewelSocketId of 0 indicates that the notable does not appear in the radius of a jewel socket
+                    if (exportRow.JewelSocketId > 0)
+                    {
+                        export.Add(exportRow);
+                    }
                 }
 
                 dataInternal[notableIndex * maxSeed + jewel_index] = passiveSkillIndex;
@@ -484,7 +477,7 @@ public static class Program
     private static TimelessJewel GetTimelessJewel(uint seed, uint jewelType)
     {
         AlternateTreeVersion alternateTreeVersion = DataManager.AlternateTreeVersions
-            .First(q => q.Index == jewelType);
+            .First(q => (q.Index == jewelType));
         return new TimelessJewel(alternateTreeVersion, seed);
     }
 
@@ -516,7 +509,7 @@ public static class Program
     private static void PromptUserForFile(string query, out string response, bool isDir = false)
     {
         TextPrompt<string> fileTextPrompt = new TextPrompt<string>(query)
-            .Validate(input =>
+            .Validate((string input) =>
             {
                 if (!isDir && !File.Exists(input))
                 {
@@ -535,5 +528,37 @@ public static class Program
             fileTextPrompt.AddChoice(choice);
         }
         response = choices.IndexOf(AnsiConsole.Prompt(fileTextPrompt));
+    }
+
+    private static string CreateCSVFile(List<CsvExportRow> csvExport, string outputDir, string outputFile, bool compress = false)
+    {
+        var outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, compress ? "csv.gz" : "csv"));
+        if (File.Exists(outputPath))
+        {
+            File.Delete(outputPath);
+        }
+
+        if(compress) {
+
+            using var fileStream = File.Create(outputPath);
+            using var gzipStream = new GZipStream(fileStream, CompressionMode.Compress);
+            using var writer = new StreamWriter(gzipStream);
+            writer.Write(SerializeCSV(csvExport));
+
+        } else
+        {
+            File.WriteAllText(outputPath, SerializeCSV(csvExport));
+        }
+
+        return outputPath;
+    }
+
+    private static string SerializeCSV(List<CsvExportRow> csvExport)
+    {
+        return CsvSerializer.SerializeToCsv(
+            csvExport
+                .OrderBy(s => s.JewelSeed)
+                .ThenBy(s => s.JewelSocketId)
+        );
     }
 }

--- a/Datafile Generator/DatafileGenerator/Source/Program.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Program.cs
@@ -178,21 +178,25 @@ public static class Program
             }
             if (isCsvExport)
             {
-                AnsiConsole.MarkupLine("[green]Generating CSV file[/]...");
-                outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, "csv"));
+                AnsiConsole.MarkupLine("[green]Generating GZipped CSV file[/]...");
+                outputPath = Path.Combine(outputDir, Path.ChangeExtension(outputFile, "csv.gz"));
                 if (File.Exists(outputPath))
                 {
                     File.Delete(outputPath);
                 }
 
-                File.WriteAllText(
-                    outputPath, 
-                    CsvSerializer.SerializeToCsv(
-                        csvExport
-                            .OrderBy(s => s.JewelSeed)
-                            .ThenBy(s => s.JewelSocketId)
-                    )
-                );
+                using (var fileStream = File.Create(outputPath))
+                using (var gzipStream = new GZipStream(fileStream, CompressionMode.Compress))
+                using (var writer = new StreamWriter(gzipStream))
+                {
+                    writer.Write(
+                        CsvSerializer.SerializeToCsv(
+                            csvExport
+                                .OrderBy(s => s.JewelSeed)
+                                .ThenBy(s => s.JewelSocketId)
+                        )
+                    );
+                }
             }
             //log completion
             sw.Stop();

--- a/Datafile Generator/DatafileGenerator/Source/Program.cs
+++ b/Datafile Generator/DatafileGenerator/Source/Program.cs
@@ -22,7 +22,6 @@ public static class Program
 
     private const int MightOfTheVaal = 76;
     private const int LegacyOfTheVaal = 77;
-
     private const int MaxBytesInFile = 5242880; //5MB
     private static int NumAdditions;
     private const string LuaMappingFileName = "NodeIndexMapping.lua";
@@ -33,7 +32,6 @@ public static class Program
         Console.Title = $"{GeneratorSettings.ApplicationName} (v{GeneratorSettings.ApplicationVersion})";
         //prompt
         AnsiConsole.MarkupLine("[green]Spinning up[/]!");
-
         // Load input files
         GeneratorSettings.AlternatePassiveAdditionsFilePath = Path.GetFullPath(@"source-data\alternatepassiveadditions.json");
         if(!File.Exists(GeneratorSettings.AlternatePassiveAdditionsFilePath)){
@@ -67,6 +65,7 @@ public static class Program
 
         if (!DataManager.Initialize())
             ExitWithError("Failed to initialize the [yellow]data manager[/].");
+        NumAdditions = DataManager.AlternatePassiveAdditions.Count;
         if (!Directory.Exists(outputDir))
             Directory.CreateDirectory(outputDir);
 
@@ -107,7 +106,6 @@ public static class Program
             var sw = Stopwatch.StartNew();
             GetJewelTypeInfo(i, out _, out _, out _, out string outputFile);
             byte[] dataBuffer;
-
             //glorious vanity logic
             if (i == 1)
             {
@@ -134,7 +132,7 @@ public static class Program
             {
                 GenerateRegular(justNotables, isCsvExport, i, notableJewelSocketMappings, out dataBuffer, out csvExport);
             }
-
+            //output uncompressed
             if (compression == OutputUncompressedFiles || compression == OutputBothFileFormats)
             {
                 AnsiConsole.MarkupLine("[green]Generating uncompressed output file[/]...");
@@ -148,7 +146,7 @@ public static class Program
                 file.Write(dataBuffer, 0, dataBuffer.Length);
                 }
             }
-
+            //output compressed
             if (compression == OutputCompressedFiles || compression == OutputBothFileFormats)
             {
                 AnsiConsole.MarkupLine("[green]Generating compressed output file[/]...");
@@ -202,7 +200,7 @@ public static class Program
                 AnsiConsole.MarkupLine($"[blue]File available at:[/] {outputPath}");
             }
         }
-        AnsiConsole.MarkupLine("[blue]Done[/]!");
+        AnsiConsole.MarkupLine("[green]Done[/]!");
     }
 
     private static List<PassiveSkill> GetModifiableNodes(bool notables)
@@ -276,7 +274,6 @@ public static class Program
                         rolls.Add((byte)skillInfo.StatRolls[(uint)k]);
                     }
                 }
-
                 //save the data
                 var dataEntry = new List<byte>(indices);
                 dataEntry.AddRange(rolls);
@@ -325,7 +322,6 @@ public static class Program
 
         int maxSeed = (jewelMax - jewelMin) / jewelIncrement + 1;
         byte[] dataInternal = new byte[maxSeed * nodes.Count];
-
         //re-index our additions and replacements to consider only this jewel type
         uint numAdditions = (uint)DataManager.AlternatePassiveAdditions.Count;
         var jewelEffectOptions = DataManager.AlternatePassiveAdditions.Where(x => x.AlternateTreeVersionIndex == jewelType).Select(x => x.Index)
@@ -383,8 +379,7 @@ public static class Program
                 }
                 else
                 {
-                    var augment = alternateTreeManager.AugmentPassiveSkill().FirstOrDefault();
-                    notableIndex = augment?.AlternatePassiveAddition.Index ?? 0;
+                    notableIndex = alternateTreeManager.AugmentPassiveSkill().FirstOrDefault()?.AlternatePassiveAddition.Index ?? 0;
                     notableReplacementName = notableJewelReplacementNames[notableIndex];
                     passiveSkillIndex = jewelEffectOptions[notableIndex];
                 }

--- a/Datafile Generator/DatafileGenerator/output-data/README.md
+++ b/Datafile Generator/DatafileGenerator/output-data/README.md
@@ -1,0 +1,1 @@
+This file is present to ensure that the parent directory exists

--- a/Datafile Generator/DatafileGenerator/source-data/README.md
+++ b/Datafile Generator/DatafileGenerator/source-data/README.md
@@ -1,0 +1,1 @@
+This file is present to ensure that the parent directory exists

--- a/README.md
+++ b/README.md
@@ -138,5 +138,5 @@ If you'd like to export human-readable CSV data dumps of the Timeless Jewel nota
 2. Open `~\Datafile Generator\DatafileGenerator.sln` in Visual Studio
 3. (Optional) Add or remove `[IgnoreDataMember]` annotations in the `~\Datafile Generator\DatafileGenerator\Source\Data\Models\CsvExportRow.cs` file to specify which data fields you'd like to include in your CSV exports
 4. Run the program. If you are prompted for input files then you have saved the 3 json files in the wrong directory. You can still select them manually
-5. Choose **csv** as the export type
-6. The GZipped CSV files are exported to `~\Datafile Generator\output-data`
+5. Choose **csv** or **csv (compressed)** as the export type
+6. The (GZipped) CSV files are exported to `~\Datafile Generator\output-data`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
-# Using the data files
+# Timeless Jewel Datafile Generator
+
+## Before you begin
+
+This tool requires several data files as inputs. Follow these steps to source the information:
+
+1. Clone this git repo from <https://github.com/Regisle/TimelessJewelData/tree/Generator>
+2. Open the latest branch
+3. Set up the `data.json` file by:
+   1. Downloading the `data.json` tree file from GGG's github: <https://github.com/grindinggear/skilltree-export/blob/master/data.json>
+   2. Saving the `data.json` file as `~\Datafile Generator\DatafileGenerator\source-data\data.json`
+4. Open <https://snosme.github.io/poe-dat-viewer/>
+5. The page shows you the **Latest PoE patch**. Paste the PoE1 Patch number into the **Patch #** field and click the **Import** button
+6. Set up the `alternatepassiveadditions.json` file by:
+   1. Use the search bar to find `AlternatePassiveAdditions`, open it and click on **Export data** in the top right
+   2. Save the `alternatepassiveadditions.json` file as `~\Datafile Generator\DatafileGenerator\source-data\alternatepassiveadditions.json`
+7. Set up the `alternatepassiveskills.json` file by:
+   1.  Use the search bar to find `AlternatePassiveSkills`, open it and click on **Export data** in the top right
+   2.  Save the `alternatepassiveskills.json` file as `~\Datafile Generator\DatafileGenerator\source-data\alternatepassiveskills.json`
+
+## Using the data files
 
 ### Parsing Brutal Restraint, Elegant Hubris, Lethal Pride, Militant Faith, and Heroic Tragedy
 
@@ -34,7 +54,7 @@ It is also possible to SEEK directly to the byte in the file that holds the desi
 
 ### Parsing Glorious Vanity
 
-Glorious Vanity, having variable stat replacments for * *all* * nodes as well as multiple stats per notable with rolls on those stats, is a much larger file (hence compressed for github), and is more complex. Its parsing method is similar to the others, but requires a fair few tweaks:
+Glorious Vanity, having variable stat replacements for * *all* * nodes as well as multiple stats per notable with rolls on those stats, is a much larger file (hence compressed for github), and is more complex. Its parsing method is similar to the others, but requires a fair few tweaks:
 
 like before:
 
@@ -95,14 +115,22 @@ is.read((char*)lut.data(), lut.size());
 
 take a random node, lets say lethal pride, Lava Lash, seed 10116 (as it ends up easier), this gives you an index of 0 + 116, the byte at that value is 52 (a "4" in ascii) which corresponds with "karui_notable_add_burning_damage", which is what it is ![](https://cdn.discordapp.com/attachments/175290321695932416/993077938847219722/unknown.png)
 
+## Generating the data files
 
-
-
-# Generating the data files
-
-Datafiles are generated using the DatafileGeneartor (a visual studio project, C#).    
-It's built on top of a timeless jewel simulator, so its not very consice, but the meat of the file format logic is in program.cs while the rest is just modelling the prng and parsing jsons.    
+Datafiles are generated using the DatafileGenerator (a visual studio project, C#).    
+It's built on top of a timeless jewel simulator, so its not very concise, but the meat of the file format logic is in program.cs while the rest is just modelling the prng and parsing jsons.
 
 It will need an alternate passive additions json, an alternate passive skills json, and the most recent skill tree json. You'll also have to tell it where to output and whether you want the compressed or uncompressed files.    
 
 Running it will output 6 datafiles, 1 lua file, and 1 csv file (note that if compressed, the Glorious Vanity "file" will actually come out to be multiple files each with size at most 5MB due to the limitations within Path of Building).
+
+## Generating CSV files
+
+If you'd like to export human-readable CSV data dumps of the Timeless Jewel notable replacements, do the following
+
+1. Follow the steps outlines in [Before you begin](#before-you-begin)
+2. Open `~\Datafile Generator\DatafileGenerator.sln` in Visual Studio
+3. (Optional) Add or remove `[IgnoreDataMember]` annotations in the `~\Datafile Generator\DatafileGenerator\Source\Data\Models\CsvExportRow.cs` file to specify which data fields you'd like to include in your CSV exports
+4. Run the program. If you are prompted for input files then you have saved the 3 json files in the wrong directory. You can still select them manually
+5. Choose **csv** as the export type
+6. The GZipped CSV files are exported to `~\Datafile Generator\output-data`

--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@ This tool requires several data files as inputs. Follow these steps to source th
 4. Open <https://snosme.github.io/poe-dat-viewer/>
 5. The page shows you the **Latest PoE patch**. Paste the PoE1 Patch number into the **Patch #** field and click the **Import** button
 6. Set up the `alternatepassiveadditions.json` file by:
-   1. Use the search bar to find `AlternatePassiveAdditions`, open it and click on **Export data** in the top right
-   2. Save the `alternatepassiveadditions.json` file as `~\Datafile Generator\DatafileGenerator\source-data\alternatepassiveadditions.json`
+   1. Select the `data` folder from the left-hand navigation pane to open it
+   2. Use the search box in the top-left of the screen to search for `AlternatePassiveAdditions`
+   3. Select the `alternatepassiveadditions.datc64` file
+   4. Click on **Export data** in the top-right of the screen
+   5. Save the `alternatepassiveadditions.json` file as `~\Datafile Generator\DatafileGenerator\source-data\alternatepassiveadditions.json`
 7. Set up the `alternatepassiveskills.json` file by:
-   1.  Use the search bar to find `AlternatePassiveSkills`, open it and click on **Export data** in the top right
-   2.  Save the `alternatepassiveskills.json` file as `~\Datafile Generator\DatafileGenerator\source-data\alternatepassiveskills.json`
+   1.  Clear the previous search
+   2.  Use the search bar to find `AlternatePassiveSkills`
+   3.  Select the `alternatepassiveskills.datc64` file
+   4.  Click on **Export data** in the top-right of the screen
+   5.  Save the `alternatepassiveskills.json` file as `~\Datafile Generator\DatafileGenerator\source-data\alternatepassiveskills.json`
 
 ## Using the data files
 


### PR DESCRIPTION
Addresses #15 

## Key Changes

 - Add CSV exports to the tool. These can either be saved as `.csv` files or as compressed `.csv.gz` files
 - Add logic for calculating the jewel socket associated with each notable transformation. This is only used by the CSV export
 - Add a step-by-step guide on to how to find the input files for the tool

## Other Changes

 - Increment tool version from `1.2` to `1.3`
 - Add a .gitignore file to prevent temporary files from the compilation process from being submitted to the git repo
 - Upgraded the `Spectre.Console` package
 - Added the `ServiceStack` and `ServiceStack.Text` packages to allow simple exporting of CSV files from objects
 - Added logic to automatically pick up the input data files if they are present. If they are not present, revert to the previous prompt-based logic
 - Slightly reformat the output of the console app

## Testing

I have generated the binary and compressed binary files using the new branch. The file sizes of the compressed archives are identical and the contents of the uncompressed files appear identical too (from a visual inspection). File sizes all match